### PR TITLE
feat(event,guild): refactor event database lock, migrate event read flow and add guild info APIs

### DIFF
--- a/ctfeed.py
+++ b/ctfeed.py
@@ -91,6 +91,7 @@ app.include_router(router.auth_router)
 app.include_router(router.user_router)
 app.include_router(router.ctf_router)
 app.include_router(router.config_router)
+app.include_router(router.guild_router)
 
 # index
 @app.get("/", tags=["Shirakami Fubuki"])

--- a/notes/event.md
+++ b/notes/event.md
@@ -8,16 +8,13 @@
   - ``finish_after`` mode: ``finish_after=int((datetime.now(timezone.utc) + timedelta(days=settings.DATABASE_SEARCH_DAYS)).timestamp())``
   - 我們需要限制讀出的數量，避免 DoS
   - 為避免日後讀取程式碼困難，使用不同的 mode 需要明確傳參（如 finish_before=None，就算是 None 也要傳）
-
-<!--
 - 請確保在操作 Database 中的 events table 時遵循以下流程，並確保整個流程被包覆在``try...except...finally...``中：
-  1. 使用 ``src.crud.try_lock_event`` 對單個 event 加鎖
-  2. 從資料庫中讀取新的 Event 物件
-  3. （如果有需要，如創建頻道後將 ID 更新到資料庫）操作 Discord Bot
-  4. 更新資料庫中的資料
-  5. 在``finally...``區塊中解鎖
-  6. 如有發生錯誤，在``except...``區塊中 rollback（例如：刪除創建出來的 Discord channel）
--->
+  1. 使用 ``src.crud.read_event(..., lock=True, duration=120) 對單個 event 加鎖，並獲取物件
+  2. （如果有需要，如創建頻道後將 ID 更新到資料庫）操作 Discord Bot
+  3. 更新資料庫中的資料
+  4. 在``finally...``區塊中解鎖
+  5. 如有發生錯誤，在``except...``區塊中 rollback（例如：刪除創建出來的 Discord channel）
+  - 純讀取不受此限制
 
 ## Docs
 

--- a/notes/event.md
+++ b/notes/event.md
@@ -1,7 +1,78 @@
 # About Event
+## Rules
 - **時區都是 utc+0** (要記得轉換)
     - ``datetime.now(timezone.utc)``
     - ``datetime_obj_with_timezone.astimezone(timezone.utc)``
-- 在讀取（即使用``read_event()``）的時候，如果不是確定「只會返回最多一個結果」的情境
-    - finish_after=``int((datetime.now(timezone.utc) + timedelta(days=settings.DATABASE_SEARCH_DAYS)).timestamp())``
-    - 我們需要限制讀出的數量，避免 DoS
+- 批量讀取 Event
+  - 使用 ``read_event_many()``
+  - ``finish_after`` mode: ``finish_after=int((datetime.now(timezone.utc) + timedelta(days=settings.DATABASE_SEARCH_DAYS)).timestamp())``
+  - 我們需要限制讀出的數量，避免 DoS
+  - 為避免日後讀取程式碼困難，使用不同的 mode 需要明確傳參（如 finish_before=None，就算是 None 也要傳）
+
+<!--
+- 請確保在操作 Database 中的 events table 時遵循以下流程，並確保整個流程被包覆在``try...except...finally...``中：
+  1. 使用 ``src.crud.try_lock_event`` 對單個 event 加鎖
+  2. 從資料庫中讀取新的 Event 物件
+  3. （如果有需要，如創建頻道後將 ID 更新到資料庫）操作 Discord Bot
+  4. 更新資料庫中的資料
+  5. 在``finally...``區塊中解鎖
+  6. 如有發生錯誤，在``except...``區塊中 rollback（例如：刪除創建出來的 Discord channel）
+-->
+
+## Docs
+
+### ``read_event_one``
+
+#### 用途
+- 用於讀取單一 Event（以 ``id`` 為主鍵）
+- 可選擇是否同時嘗試加鎖（給後續更新流程使用）
+
+#### 使用方法
+- 只讀取（不加鎖）
+    - ``lock=False``
+    - 回傳：``(event_db, None)``
+- 讀取並嘗試加鎖
+    - ``lock=True`` 且 ``duration`` 必填
+    - 成功：回傳 ``(event_db, lock_owner_token)``
+    - Event 不存在：``NotFoundError``
+    - Event 已被鎖住：``LockedError``
+- ``type`` 可為 ``ctftime`` / ``custom`` / ``None``，用來限制 Event 類型
+- ``archived`` 可為 ``True`` / ``False`` / ``None``，用來限制封存狀態
+
+#### 設計說明
+- 單筆查詢一律以 ``Event.id`` 為核心條件
+- 加鎖模式採用原子條件更新（``locked_until`` + ``locked_by``）避免競態
+- 回傳的 ``lock_owner_token`` 需在後續 ``update_event`` / ``unlock_event`` 使用
+
+
+### ``read_event_many``
+
+#### 用途
+- 用於讀取多筆 Event，給 API 列表查詢與背景工作使用
+- 支援 ``ctftime`` 與 ``custom`` 兩種查詢模式
+
+#### 使用方法
+- ``type=ctftime``
+    - ``finish_after`` mode
+        - 只傳 ``finish_after``
+        - 不能同時傳 ``finish_before``、``limit``、``before_id``
+    - ``finish_before`` mode
+        - ``finish_after`` 必須是 ``None``
+        - ``limit`` 必填且需大於 0
+        - 第一頁：``finish_before=None`` 且 ``before_id=None``
+        - 下一頁：帶上前一頁最後一筆的 ``finish`` 和 ``id``（即 ``finish_before``、``before_id``）
+- ``type=custom``
+    - ``limit`` 必填且需大於 0
+    - 第一頁：``before_id=None``
+    - 下一頁：帶上前一頁最後一筆 ``id`` 到 ``before_id``
+- 不能傳 ``finish_after`` / ``finish_before``
+- ``archived`` 可選，用於限制封存狀態
+
+#### 設計說明
+- ``ctftime`` 分頁採用複合游標條件：
+    - 排序：``ORDER BY finish DESC, id DESC``
+    - 下一頁條件：``finish < finish_before`` 或 ``(finish == finish_before and id < before_id)``
+- ``custom`` 分頁採用 ``id`` 游標：
+    - 排序：``ORDER BY id DESC``
+    - 下一頁條件：``id < before_id``
+- 參數組合會在函式內做嚴格檢查，不合法時拋 ``ValueError``

--- a/src/backend/channel_op.py
+++ b/src/backend/channel_op.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Tuple
 import logging
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,8 +21,28 @@ from src import crud
 # logging
 logger = logging.getLogger("uvicorn")
 
+# utils
+async def read_event_one_wrapper(session:AsyncSession, event_db_id:int) -> Tuple[model.Event, str]:
+    try:
+        event_db, lock_owner_token = await crud.read_event_one(
+            session=session,
+            lock=True, duration=120,
+            archived=False, # ensoure the Event isn't archived
+            id=event_db_id
+        )
+    except crud.NotFoundError:
+        raise HTTPException(404, f"Event (id={event_db_id}) not found (archived, or invalid id)")
+    except crud.LockedError:
+        raise HTTPException(423, F"Event (id={event_db_id}) was locked. Try again later.")
+    except Exception as e:
+        logger.error(f"Can't get and lock Event (id={event_db_id}): {str(e)}")
+        raise HTTPException(500, f"Can't get and lock Event (id={event_db_id})")
+    
+    return event_db, lock_owner_token
+
+
 # functions
-async def _create_channel(session:AsyncSession, member:discord.Member, event_db_id:int, lock_owner_token:str):
+async def _create_channel(session:AsyncSession, member:discord.Member, event_db:model.Event, lock_owner_token:str) -> model.Event:
     # 在這個 function 有 exception 就直接 raise 出來
     channel:Optional[discord.TextChannel] = None
     event_api:Optional[Dict[str, Any]] = None
@@ -43,23 +63,13 @@ async def _create_channel(session:AsyncSession, member:discord.Member, event_db_
     
     try:
         async with session.begin():
-            # get a new event_db
-            events_db = await crud.read_event(
-                session,
-                id=event_db_id,
-                archived=False, # ensure the event isn't archived
-                lock_owner_token=lock_owner_token
-            )
-            if len(events_db) != 1:
-                raise RuntimeError(f"Event (id={event_db_id}) not found")
-            event_db = events_db[0]
             ctftime_event = True if event_db.event_id is not None else False
             
             # check channel
             if (channel_id := event_db.channel_id) is not None and \
                     guild.get_channel(channel_id) is not None:
                 # exists -> no need to create
-                return
+                return event_db
 
             if ctftime_event:
                 events_api = await ctf_api.fetch_ctf_events(event_db.event_id)
@@ -107,11 +117,11 @@ async def _create_channel(session:AsyncSession, member:discord.Member, event_db_
         except Exception as e:
             logger.error(f"fail to send notification to channel (id={channel.id}): {str(e)}")
             # ignore exception
-    
-    return
+
+    return event_db
 
 
-async def _join_channel(session:AsyncSession, member:discord.Member, event_db_id:int, lock_owner_token:str):
+async def _join_channel(session:AsyncSession, member:discord.Member, event_db:model.Event, lock_owner_token:str):
     # 在這個 function 有 exception 就直接 raise 出來
     # get guild
     bot = await get_bot()
@@ -124,21 +134,10 @@ async def _join_channel(session:AsyncSession, member:discord.Member, event_db_id
     log_msg:str = ""
     try:
         async with session.begin():
-            # get a new event_db
-            events_db = await crud.read_event(
-                session,
-                id=event_db_id,
-                archived=False, # ensure the Event isn't archived
-                lock_owner_token=lock_owner_token
-            )
-            if len(events_db) != 1:
-                raise RuntimeError(f"Event (id={event_db_id}) not found")
-            event_db = events_db[0]
-            
             # check channel
             if (channel_id := event_db.channel_id) is None or \
                 (channel := guild.get_channel(channel_id)) is None:
-                raise RuntimeError(f"TextChannel for Event (id={event_db_id}) not found")
+                raise RuntimeError(f"TextChannel for Event (id={event_db.id}) not found")
             
             # join channel
             await channel.set_permissions(member, view_channel=True)
@@ -146,10 +145,10 @@ async def _join_channel(session:AsyncSession, member:discord.Member, event_db_id
             
             # update database
             try:
-                await crud.join_event(session, event_db_id, member.id, lock_owner_token)
+                await crud.join_event(session, event_db.id, member.id, lock_owner_token)
             except IntegrityError:
                 # ignore
-                raise HTTPException(409, f"The user (discord_id={member.id}) has joined the Event (id={event_db_id})")
+                raise HTTPException(409, f"The user (discord_id={member.id}) has joined the Event (id={event_db.id})")
             except Exception:
                 raise
             joined = True
@@ -196,22 +195,14 @@ async def create_and_join_channel(member:discord.Member, event_db_id:int):
     lock_owner_token:Optional[str] = None
     async with database.with_get_db() as session:
         # try to lock event
-        try:
-            lock_owner_token = await crud.try_lock_event(session, event_db_id, 120)
-        except crud.LockedError:
-            raise HTTPException(423, f"Event (id={event_db_id}) was locked. Try again later.")
-        except crud.NotFoundError:
-            raise HTTPException(404, f"Event (id={event_db_id}) not found")
-        except Exception as e:
-            logger.error(f"Can't lock Event (id={event_db_id}): {str(e)}")
-            raise HTTPException(f"Can't lock Event (id={event_db_id}): {str(e)}")
+        event_db, lock_owner_token = await read_event_one_wrapper(session, event_db_id)
 
         try:
             # try to create channel
-            await _create_channel(session, member, event_db_id, lock_owner_token)
+            event_db = await _create_channel(session, member, event_db, lock_owner_token)
             
             # join channel
-            await _join_channel(session, member, event_db_id, lock_owner_token)
+            await _join_channel(session, member, event_db, lock_owner_token)
         except Exception as e:
             if isinstance(e, HTTPException):
                 raise
@@ -250,30 +241,9 @@ async def archive_event(event_db_id:int, reason:str):
         raise HTTPException(500, f"Archive Category (id={settings.ARCHIVE_CATEGORY_ID}) not found")
     
     async with database.with_get_db() as session:
-        # try to lock the Event
-        try:
-            lock_owner_token = await crud.try_lock_event(session, event_db_id, 120)
-        except crud.NotFoundError:
-            raise HTTPException(404, f"Event (id={event_db_id}) not found")
-        except crud.LockedError:
-            raise HTTPException(423, f"Event (id={event_db_id}) was locked. Try again later.")
-        except Exception as e:
-            logger.error(f"Can't lock Event (id={event_db_id}): {str(e)}")
-            raise HTTPException(500, f"Can't lock Event (id={event_db_id})")
-        
+        event_db, lock_owner_token = await read_event_one_wrapper(session, event_db_id)
         try:
             async with session.begin():
-                # get a new event_db
-                events_db = await crud.read_event(
-                    session=session,
-                    archived=False, # ensure the Event isn't archived
-                    id=event_db_id,
-                    lock_owner_token=lock_owner_token,
-                )
-                if len(events_db) != 1:
-                    raise RuntimeError(f"Event (id={event_db_id}) not found")
-                event_db = events_db[0]
-                
                 # update database
                 event_db:model.Event = await crud.update_event(
                     session=session,
@@ -371,30 +341,9 @@ async def link_event_to_channel(event_db_id:int, channel_id:int):
         raise HTTPException(400, f"Channel (id={channel_id}) not found")
     
     async with database.with_get_db() as session:
-        # try to lock the Event
-        try:
-            lock_owner_token = await crud.try_lock_event(session, event_db_id, 120)
-        except crud.NotFoundError:
-            raise HTTPException(404, f"Event (id={event_db_id}) not found")
-        except crud.LockedError:
-            raise HTTPException(423, f"Event (id={event_db_id}) was locked. Try again later.")
-        except Exception as e:
-            logger.error(f"Can't lock Event (id={event_db_id}): {str(e)}")
-            raise HTTPException(500, f"Can't lock Event (id={event_db_id})")
-        
+        event_db, lock_owner_token = await read_event_one_wrapper(session, event_db_id)
         try:
             async with session.begin():
-                # get a new event_db
-                events_db = await crud.read_event(
-                    session=session,
-                    archived=False, # ensure the Event isn't archived
-                    id=event_db_id,
-                    lock_owner_token=lock_owner_token
-                )
-                if len(events_db) != 1:
-                    raise RuntimeError(f"Event (id={event_db_id}) not found")
-                event_db = events_db[0]
-                
                 # update database
                 event_db:model.Event = await crud.update_event(
                     session=session,

--- a/src/backend/channel_op.py
+++ b/src/backend/channel_op.py
@@ -13,7 +13,7 @@ from src.utils import notification
 from src.utils import get_category
 from src.utils import ctf_api
 from src.utils import embed_creator
-from src.bot import get_bot
+from src.bot import get_guild
 from src import crud
 
 # channel_op = "event_op"
@@ -51,10 +51,7 @@ async def _create_channel(session:AsyncSession, member:discord.Member, event_db:
     log_msg:str = ""
     
     # get guild
-    bot = await get_bot()
-    if (guild := bot.get_guild(settings.GUILD_ID)) is None:
-        logger.critical(f"Guild (id={settings.GUILD_ID}) not found")
-        raise HTTPException(500, f"Guild (id={settings.GUILD_ID}) not found")
+    guild = get_guild()
     
     # get category
     if (ctf_channel_category := get_category.get_category(guild, settings.CTF_CHANNEL_CATEGORY_ID)) is None:
@@ -124,10 +121,7 @@ async def _create_channel(session:AsyncSession, member:discord.Member, event_db:
 async def _join_channel(session:AsyncSession, member:discord.Member, event_db:model.Event, lock_owner_token:str):
     # 在這個 function 有 exception 就直接 raise 出來
     # get guild
-    bot = await get_bot()
-    if (guild := bot.get_guild(settings.GUILD_ID)) is None:
-        logger.critical(f"Guild (id={settings.GUILD_ID}) not found")
-        raise HTTPException(500, f"Guild (id={settings.GUILD_ID}) not found")
+    guild = get_guild()
     
     joined_channel = False  # joined channel in Discord, but not in database
     joined = False          # joined channel in Discord and database
@@ -230,10 +224,7 @@ async def archive_event(event_db_id:int, reason:str):
     event_db_returning = {}
     
     # get guild
-    bot = await get_bot()
-    if (guild := bot.get_guild(settings.GUILD_ID)) is None:
-        logger.critical(f"Guild (id={settings.GUILD_ID}) not found")
-        raise HTTPException(500, f"Guild (id={settings.GUILD_ID}) not found")
+    guild = get_guild()
     
     # get archive category
     if (archive_category := get_category.get_category(guild, settings.ARCHIVE_CATEGORY_ID)) is None:
@@ -330,10 +321,7 @@ async def link_event_to_channel(event_db_id:int, channel_id:int):
     lock_owner_token = None
     
     # get guild
-    bot = await get_bot()
-    if (guild := bot.get_guild(settings.GUILD_ID)) is None:
-        logger.critical(f"Guild (id={settings.GUILD_ID}) not found")
-        raise HTTPException(500, f"Guild (id={settings.GUILD_ID}) not found")
+    guild = get_guild()
     
     # get channel
     if (channel := guild.get_channel(channel_id)) is None or \
@@ -377,10 +365,7 @@ async def create_custom_event(title:str):
     :raise HTTPException:
     """
     # get guild
-    bot = await get_bot()
-    if (guild := bot.get_guild(settings.GUILD_ID)) is None:
-        logger.critical(f"Guild (id={settings.GUILD_ID}) not found")
-        raise HTTPException(500, f"Guild (id={settings.GUILD_ID}) not found")
+    guild = get_guild()
     
     # create the custom event in database
     event_db_id = None

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -7,6 +7,7 @@ import discord
 
 from src import schema
 from src import crud
+from src.bot import get_guild
 from src.database import model
 from src.database import database
 from src.config import settings, settings_lock
@@ -49,7 +50,7 @@ async def check_config_valid_obj(guild:discord.Guild, key:str, value:Any) -> Tup
     return msg, _
 
 
-async def read_config(bot:commands.Bot, key:Optional[str]=None) -> schema.ConfigResponse:
+async def read_config(key:Optional[str]=None) -> schema.ConfigResponse:
     """
     Read config.
     
@@ -61,10 +62,7 @@ async def read_config(bot:commands.Bot, key:Optional[str]=None) -> schema.Config
     :raise HTTPException:
     """
     # get guild
-    guild = bot.get_guild(settings.GUILD_ID)
-    if guild is None:
-        logger.critical(f"Guild (id={settings.GUILD_ID}) not found")
-        raise HTTPException(500, f"Guild (id={settings.GUILD_ID}) not found")
+    guild = get_guild()
     
     # get config
     cache_config = {}
@@ -123,7 +121,7 @@ async def update_config_cache(config:model.Config):
                 logger.critical(f"fail to update cache of config (key={_k}) (maybe src.database.model.Config, src.database.model.config_info and src.config are out of sync): {str(e)}")
 
 
-async def update_config(bot:commands.Bot, kv:Optional[Tuple]):
+async def update_config(kv:Optional[Tuple]):
     """
     Update Config in database and cache.
     
@@ -133,10 +131,7 @@ async def update_config(bot:commands.Bot, kv:Optional[Tuple]):
     :raise HTTPException:
     """
     # get guild
-    guild = bot.get_guild(settings.GUILD_ID)
-    if guild is None:
-        logger.critical(f"Guild (id={settings.GUILD_ID}) not found")
-        raise HTTPException(500, f"Guild (id={settings.GUILD_ID}) not found")
+    guild = get_guild()
     
     # check arguments
     arg = {}

--- a/src/backend/event.py
+++ b/src/backend/event.py
@@ -1,14 +1,10 @@
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from typing import Optional, List, Literal
 import logging
 
-from sqlalchemy.ext.asyncio import AsyncSession
-from fastapi import HTTPException
 import discord
 
 from src.database import model
-from src.bot import get_bot
-from src.config import settings
 from src.backend import security
 from src import schema
 
@@ -38,11 +34,11 @@ async def format_event(guild:discord.Guild, events_db:List[model.Event]) -> List
                 now_running = False
         
         # channel
-        channel:Optional[schema.DiscordChannel] = None
+        channel:Optional[schema.DiscordTextChannel] = None
         if event.channel_id is not None:
             discord_channel = guild.get_channel(event.channel_id)
             if isinstance(discord_channel, discord.TextChannel):
-                channel = schema.DiscordChannel(
+                channel = schema.DiscordTextChannel(
                     id=discord_channel.id,
                     jump_url=discord_channel.jump_url,
                     name=discord_channel.name
@@ -88,11 +84,3 @@ async def format_event(guild:discord.Guild, events_db:List[model.Event]) -> List
         ))
     
     return result
-
-
-async def get_guild() -> discord.Guild:
-    bot = await get_bot()
-    if (guild := bot.get_guild(settings.GUILD_ID)) is None:
-        logger.critical(f"Guild (id={settings.GUILD_ID}) not found")
-        raise HTTPException(500, f"Guild (id={settings.GUILD_ID}) not found")
-    return guild

--- a/src/backend/security.py
+++ b/src/backend/security.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 import logging
 
 from sqlalchemy.exc import IntegrityError
@@ -9,10 +9,30 @@ import discord
 from src.config import settings, settings_lock
 from src.database.database import with_get_db
 from src.bot import get_bot
+from src import schema
 from src import crud
 
 # logging
 logger = logging.getLogger("uvicorn")
+
+# utils
+async def get_role(member:discord.Member) -> List[schema.UserRole]:
+    roles = []
+    if member.guild_permissions.administrator == True:
+        roles.append(schema.UserRole.administrator)
+    
+    async with settings_lock:
+        pm_role_id = settings.PM_ROLE_ID
+        member_role_id = settings.MEMBER_ROLE_ID
+    
+    if member.get_role(pm_role_id):
+        roles.append(schema.UserRole.pm)
+    
+    if member.get_role(member_role_id):
+        roles.append(schema.UserRole.member)
+    
+    return roles
+    
 
 # functions
 async def check_administrator(discord_id:int) -> Optional[discord.Member]:

--- a/src/backend/user.py
+++ b/src/backend/user.py
@@ -7,7 +7,7 @@ from fastapi import HTTPException
 
 from src.database import model
 from src.backend import security
-from src.schema import User, DiscordUser, EventSimple
+from src.schema import UserRole, User, DiscordUser, EventSimple
 from src.bot import get_bot
 from src.config import settings
 from src import crud
@@ -79,15 +79,19 @@ async def get_user(session:AsyncSession, discord_id:Optional[int]=None) -> List[
 
         # discord user
         discord_user:Optional[DiscordUser] = None
+        user_role:List[UserRole] = []
         if member is not None:
             discord_user = DiscordUser(
                 display_name=member.display_name,
                 id=member.id,
                 name=member.name
             )
+            
+            user_role = await security.get_role(member)
 
         result.append(User(
             discord_id=db_user.discord_id,
+            user_role=user_role,
             status=db_user.status,
             skills=db_user.skills,
             rhythm_games=db_user.rhythm_games,

--- a/src/backend/user.py
+++ b/src/backend/user.py
@@ -8,7 +8,7 @@ from fastapi import HTTPException
 from src.database import model
 from src.backend import security
 from src.schema import UserRole, User, DiscordUser, EventSimple
-from src.bot import get_bot
+from src.bot import get_guild
 from src.config import settings
 from src import crud
 
@@ -28,10 +28,7 @@ async def get_user(session:AsyncSession, discord_id:Optional[int]=None) -> List[
     :raise HTTPException:
     """
     # get guild
-    bot = await get_bot()
-    if (guild := bot.get_guild(settings.GUILD_ID)) is None:
-        logger.critical(f"Guild (id={settings.GUILD_ID}) not found")
-        raise HTTPException(500, f"Guild (id={settings.GUILD_ID}) not found")
+    guild = get_guild()
     
     # get user from database
     try:

--- a/src/bgtask/detect_event_update_and_remove.py
+++ b/src/bgtask/detect_event_update_and_remove.py
@@ -7,7 +7,7 @@ from src.utils import ctf_api
 from src.utils import embed_creator
 from src.utils import notification
 from src.config import settings
-from src.bot import get_bot
+from src.bot import get_guild
 from src.backend import channel_op
 from src import crud
 
@@ -27,10 +27,9 @@ async def check_and_update_event(event_db_id:int, event_api:Dict[str, Any]):
     event_db_returning = {"updated": False}
     
     # get guild
-    bot = await get_bot()
-    guild = bot.get_guild(settings.GUILD_ID)
-    if guild is None:
-        logger.critical(f"Guild (id={settings.GUILD_ID}) not found")
+    try:
+        guild = get_guild()
+    except Exception:
         return
     
     # update database

--- a/src/bgtask/detect_event_update_and_remove.py
+++ b/src/bgtask/detect_event_update_and_remove.py
@@ -35,33 +35,27 @@ async def check_and_update_event(event_db_id:int, event_api:Dict[str, Any]):
     
     # update database
     async with database.with_get_db() as session:
-        # try to lock the Event
+        # get a new event_db
         try:
-            lock_owner_token = await crud.try_lock_event(session, event_db_id, 120)
+            event_db, lock_owner_token = await crud.read_event_one(
+                session=session,
+                lock=True, duration=120,
+                type="ctftime",
+                archived=False, # ensoure the event isn't archived
+                id=event_db_id
+            )
         except crud.NotFoundError:
-            logger.error(f"Event (id={event_db_id}) not found.")
+            logger.warning(f"Event (id={event_db_id}) not found.")
             return
         except crud.LockedError:
-            logger.info(f"Event (id={event_db_id}) was locked. Skipped...")
+            logger.warning(f"Event (id={event_db_id}) was locked. Skipped...")
             return
         except Exception as e:
-            logger.error(f"Can't lock Event (id={event_db_id}): {str(e)}")
+            logger.error(f"Can't get and lock Event (id={event_db_id}): {str(e)}")
             return
-        
+
         try:
             async with session.begin():
-                # get a new event_db
-                events_db = await crud.read_event(
-                    session=session,
-                    type="ctftime",
-                    archived=False, # ensure the event isn't archived
-                    id=event_db_id,
-                    lock_owner_token=lock_owner_token
-                )
-                if len(events_db) != 1:
-                    raise RuntimeError(f"Event (id={event_db_id}) not found")
-                event_db = events_db[0]
-                
                 # check
                 if event_db.title != ntitle or \
                         event_db.start != int(nstart.timestamp()) or \
@@ -149,11 +143,14 @@ async def _detect_event_update_and_remove():
     # get all non-archived CTFTime events from database
     try:
         async with database.with_get_db() as session:
-            events_db = await crud.read_event(
+            events_db = await crud.read_event_many(
                 session=session,
                 type="ctftime",
                 archived=False,
-                finish_after=int((datetime.now(timezone.utc) + timedelta(days=settings.DATABASE_SEARCH_DAYS)).timestamp())
+                limit=None,
+                finish_after=int((datetime.now(timezone.utc) + timedelta(days=settings.DATABASE_SEARCH_DAYS)).timestamp()),
+                finish_before=None,
+                before_id=None
             )
         
         events_db_returning = [

--- a/src/bgtask/detect_events_new.py
+++ b/src/bgtask/detect_events_new.py
@@ -30,11 +30,14 @@ async def _detect_events_new():
     # archived=None - get both archived and non-archived events to avoid missing any events
     try:
         async with database.with_get_db() as session:
-            events_db = await crud.read_event(
+            events_db = await crud.read_event_many(
                 session,
                 type="ctftime",
                 archived=None,
-                finish_after=int((datetime.now(timezone.utc)+timedelta(days=settings.DATABASE_SEARCH_DAYS)).timestamp())
+                limit=None,
+                finish_after=int((datetime.now(timezone.utc)+timedelta(days=settings.DATABASE_SEARCH_DAYS)).timestamp()),
+                finish_before=None,
+                before_id=None
             )
             events_db_event_id = [event.event_id for event in events_db]
     except Exception as e:

--- a/src/bgtask/recover_scheduled_events.py
+++ b/src/bgtask/recover_scheduled_events.py
@@ -5,7 +5,7 @@ import logging
 import discord
 
 from src.database import database
-from src.bot import get_bot
+from src.bot import get_guild
 from src.config import settings
 from src import crud
 
@@ -15,9 +15,9 @@ logger = logging.getLogger("uvicorn")
 # functions
 async def do_recover(event_db_id:int):
     # get guild
-    bot = await get_bot()
-    if (guild := bot.get_guild(settings.GUILD_ID)) is None:
-        logger.critical(f"Guild (id={settings.GUILD_ID}) not found")
+    try:
+        guild = get_guild()
+    except Exception:
         return
     
     lock_owner_token:Optional[str] = None

--- a/src/bot.py
+++ b/src/bot.py
@@ -4,6 +4,7 @@ import glob
 import pathlib
 import traceback
 
+from fastapi import HTTPException
 from discord.ext import commands
 import discord
 
@@ -44,7 +45,7 @@ def load_cogs():
 # global error handler
 @bot.event
 async def on_error(event: str, *args, **kwargs):
-    logger.error(f"Unhandled exception in event ({event}): {"".join(traceback.format_exc())}")
+    logger.error(f"Unhandled exception in event ({event}): {''.join(traceback.format_exc())}")
 
 
 # startup and shutdown
@@ -68,5 +69,20 @@ async def stop_bot():
         
 
 # get bot
-async def get_bot() -> commands.Bot:
+def get_bot() -> commands.Bot:
     return bot
+
+
+# get guild
+def get_guild() -> discord.Guild:
+    """
+    Get the guild.
+    
+    :return discord.Guild:
+    
+    :raise HTTPException:
+    """
+    if (guild := bot.get_guild(settings.GUILD_ID)) is None:
+        logger.critical(f"Guild (id={settings.GUILD_ID}) not found")
+        raise HTTPException(500, f"Guild (id={settings.GUILD_ID}) not found")
+    return guild

--- a/src/bot.py
+++ b/src/bot.py
@@ -2,6 +2,7 @@ import logging
 import asyncio
 import glob
 import pathlib
+import traceback
 
 from discord.ext import commands
 import discord
@@ -38,6 +39,12 @@ def load_cogs():
             logger.info(f"{extension_name} loaded")
         except Exception as e:
             logger.critical(f"fail to load {extension_name}: {str(e)}")
+
+
+# global error handler
+@bot.event
+async def on_error(event: str, *args, **kwargs):
+    logger.error(f"Unhandled exception in event ({event}): {"".join(traceback.format_exc())}")
 
 
 # startup and shutdown

--- a/src/cog/config.py
+++ b/src/cog/config.py
@@ -24,7 +24,7 @@ class ConfigMenu(discord.ui.View):
         
         # build embed
         try:
-            config_info = await config.read_config(self.bot, self.state if self.state != "MAIN" else None)
+            config_info = await config.read_config(self.state if self.state != "MAIN" else None)
         except Exception as e:
             return discord.Embed(title=f"Fail to read config", description=str(e), color=discord.Color.red())
         
@@ -81,7 +81,7 @@ class ConfigMenu(discord.ui.View):
 
     async def on_change_page(self, interaction:discord.Interaction):
         # check permission
-        if not(await security.discord_check_administrator(interaction)):
+        if not (await security.discord_check_administrator(interaction)):
             return
         
         # check argument
@@ -125,7 +125,7 @@ class ConfigMenu(discord.ui.View):
         
         # update
         try:
-            await config.update_config(self.bot, (self.state, value))
+            await config.update_config((self.state, value))
         except Exception as e:
             await interaction.response.send_message(f"fail to update config (key={self.state}): {str(e)}", ephemeral=True)
             return

--- a/src/cog/user.py
+++ b/src/cog/user.py
@@ -33,17 +33,18 @@ class UserMenu(discord.ui.View):
         
         # build embed
         color = discord.Color.green() if user_s.status == model.Status.online else discord.Color.red()
+        user_role_s = ", ".join([r.value for r in user_s.user_role])
         
         if user_s.discord is not None:
             embed = discord.Embed(
                 title=f"{user_s.discord.display_name}",
-                description=f"Name: {user_s.discord.name}\nID: {user_s.discord.id}",
+                description=f"Name: {user_s.discord.name}\nID: {user_s.discord.id}\nRoles: {user_role_s}",
                 color=color
             )
         else:
             embed = discord.Embed(
                 title=f"(Invalid)",
-                description=f"Name: (Invalid)\nID: {user_s.discord_id}",
+                description=f"Name: (Invalid)\nID: {user_s.discord_id}\nRoles: {user_role_s}",
                 color=color
             )
         

--- a/src/crud/__init__.py
+++ b/src/crud/__init__.py
@@ -1,8 +1,8 @@
 from .config import create_or_update_config, read_config
 from .user import create_user, read_user, update_user
 from .event import (
-    try_lock_event, unlock_event,
+    unlock_event,
     NotFoundError, LockedError,
     join_event, delete_user_in_event,
-    create_event, read_event, read_ctfime_events_need_archive, update_event,
+    create_event, read_event_one, read_event_many, read_ctfime_events_need_archive, update_event,
 )

--- a/src/crud/config.py
+++ b/src/crud/config.py
@@ -59,6 +59,7 @@ async def create_or_update_config(
     try:
         result = (await session.execute(stmt)).scalar_one()
         await session.flush()
+        await session.refresh(result)
         return result
     except Exception:
         raise

--- a/src/crud/event.py
+++ b/src/crud/event.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Literal
+from typing import List, Optional, Literal, Tuple, Union
 from datetime import datetime, timedelta, timezone
 import hashlib
 import os
@@ -17,72 +17,149 @@ class NotFoundError(Exception):
 class LockedError(Exception):
     pass
 
-async def try_lock_event(session:AsyncSession, id:int, duration:int) -> str:
-    """
-    Try to lock an Event.
-    
-    :param session:
-    :param id: The Event which you want to lock.
-    :param duration: How long you want to lock the Event (in seconds).
-    
-    :return str: Lock owner token.
-    
-    :raise NotFoundError: Can't find the Event.
-    :raise LockedError: The Event was locked.
-    :raise (Exception from sqlalchemy):
-    """
-    # time and lock_owner_token
-    time_now = datetime.now(timezone.utc)
-    locked_until = time_now + timedelta(seconds=duration)
-    lock_owner_token = hashlib.sha256(os.urandom(32)).hexdigest()
-    
-    # stmt
-    check_exists_cte = (
-        sqlalchemy.select(Event.id) \
-        .where(Event.id == id)
-    ).cte("check_exists_cte")
-    
-    try_lock_cte = (
-        sqlalchemy.update(Event) \
-        .where(Event.id == id) \
-        .where(sqlalchemy.or_(
-            Event.locked_until == None,
-            Event.locked_until < int(time_now.timestamp()) # expired
-        )) \
-        .values(
-            locked_until=int(locked_until.timestamp()),
-            locked_by=lock_owner_token
-        ) \
-        .returning(Event)
-    ).cte("try_lock_cte")
-    
-    check_lock = sqlalchemy.exists(
-        sqlalchemy.select(try_lock_cte.c.id) \
-        .where(try_lock_cte.c.id == id) \
-        .where(try_lock_cte.c.locked_by == lock_owner_token)
-    )
-    
-    stmt = sqlalchemy.select(
-        sqlalchemy.case(
-            (check_lock, "success"),
-            else_="locked"
-        ),
-    ) \
-    .where(check_exists_cte.c.id == id)
-    
-    # execute
-    async with session.begin():
-        status = (await session.execute(stmt)).one_or_none()
-    
-    if status is None:
-        raise NotFoundError
-    else:
-        status = status[0]
-        if status == "success":
-            return lock_owner_token
-        elif status == "locked":
-            raise LockedError
-
+#async def read_event(
+#    session:AsyncSession,
+#    # lock
+#    lock:bool,
+#    duration:Optional[int]=None,
+#    # filters
+#    type:Optional[Literal["ctftime", "custom"]]=None,
+#    archived:Optional[bool]=None,
+#    id:Optional[int]=None,
+#    channel_id:Optional[int]=None,
+#    # only for CTFTime Events
+#    event_id:Optional[int]=None,
+#    finish_after:Optional[int]=None,
+#) -> Tuple[List[Event], Optional[str]]:
+#    """
+#    Read Events and try to lock an Event.
+#    
+#    :param session:
+#    :param lock: Whether to lock the Event.
+#    :param duration:
+#    :param type: Search "ctftime", "custom" Events, or ``None`` to search both types of Events.
+#    :param archived: Search archived, non-archived Events, or ``None`` to search both types of Events.
+#    :param id:
+#    :param channel_id: Discord channel ID.
+#    :param event_id: (CTFTime Event only) CTFTime Event id.
+#    :param finish_after: (CTFTime Event only) search CTFTime Events which finish after ``finish_after``.
+#    
+#    :return List[Event]: A list of Events.
+#    :return str: Lock owner token.
+#    
+#    :raise NotFoundError: Can't find the Event (when id, channel_id or event_id is not None).
+#    :raise LockedError: The Event was locked.
+#    :raise ValueError:
+#    :raise (Exception from sqlalchemy):
+#    """
+#    # functions
+#    def _build_filter(stmt):
+#        if type is not None:
+#            if type == "ctftime":
+#                if event_id is not None:
+#                    stmt = stmt.where(Event.event_id == event_id)
+#                else:
+#                    stmt = stmt.where(Event.event_id != None)
+#
+#                if finish_after is not None:
+#                    stmt = stmt.where(Event.finish >= finish_after)
+#                    
+#                # sorting
+#                if isinstance(stmt, sqlalchemy.Select):
+#                    stmt = stmt.order_by(sqlalchemy.asc(Event.finish))
+#            elif type == "custom":
+#                stmt = stmt.where(Event.event_id == None)
+#            else:
+#                raise ValueError(f"type should be \"ctftime\", \"custom\" or None")
+#        
+#        if archived is not None:
+#            stmt = stmt.where(Event.archived == archived)
+#    
+#        if id is not None:
+#            stmt = stmt.where(Event.id == id)
+#
+#        if channel_id is not None:
+#            stmt = stmt.where(Event.channel_id == channel_id)
+#        
+#        return stmt
+#    
+#    # check exists stmt
+#    check_exists = sqlalchemy.select(Event) \
+#        .options(selectinload(Event.users))
+#    check_exists:sqlalchemy.Select = _build_filter(check_exists)
+#    
+#    # no need to lock -> execute and return
+#    if lock == False:
+#        try:
+#            results = (await session.execute(check_exists)).scalars().all()
+#        except Exception:
+#            raise
+#        if len(results) == 0:
+#            raise NotFoundError
+#        return results, None
+#    
+#    # need to lock
+#    # only effective when id is not None
+#    if id is None:
+#        raise ValueError("id should not be None when lock is True")
+#        
+#    # argument check
+#    if duration is None:
+#        raise ValueError("duration should not be None when lock is True")
+#
+#    # prepare arguments
+#    time_now = datetime.now(timezone.utc)
+#    locked_until = time_now + timedelta(seconds=duration)
+#    lock_owner_token = hashlib.sha256(os.urandom(32)).hexdigest()
+#    
+#    # stmt
+#    check_exists_cte = check_exists.cte("check_exists_cte")
+#    
+#    try_lock = sqlalchemy.update(Event)
+#    try_lock:sqlalchemy.Update = _build_filter(try_lock)
+#    try_lock_cte = (
+#        try_lock
+#        .where(sqlalchemy.or_(
+#            Event.locked_until == None,
+#            Event.locked_until < int(time_now.timestamp())
+#        ))
+#        .values(
+#            locked_until=int(locked_until.timestamp()),
+#            locked_by=lock_owner_token
+#        )
+#        .returning(Event)
+#    ).cte("try_lock_cte")
+#    
+#    check_lock = sqlalchemy.exists(
+#        sqlalchemy.select(try_lock_cte.c.id) \
+#        .where(try_lock_cte.c.id == id) \
+#        .where(try_lock_cte.c.locked_by == lock_owner_token)
+#    )
+#    
+#    stmt = sqlalchemy.select(
+#        sqlalchemy.case(
+#            (check_lock, "success"),
+#            else_="locked"
+#        ),
+#        Event
+#    ) \
+#    .options(selectinload(Event.users)) \
+#    .join(check_exists_cte, check_exists_cte.c.id == Event.id) \
+#    .where(check_exists_cte.c.id == id)
+#    
+#    # execute
+#    async with session.begin():
+#        results = (await session.execute(stmt)).all()
+#        if len(results) == 0:
+#            raise NotFoundError
+#        else:
+#            status = results[0][0]
+#            event_db = results[0][1]
+#            if status == "success":
+#                return [event_db], lock_owner_token
+#            elif status == "locked":
+#                raise LockedError
+#
 
 async def unlock_event(session:AsyncSession, id:int, lock_owner_token:str) -> bool:
     """
@@ -280,35 +357,165 @@ async def create_event(
 
 
 # read
-async def read_event(
+async def read_event_one(
     session:AsyncSession,
-    # lock
-    lock_owner_token:Optional[str]=None,
-    # conditions
+    id:int,
+    lock:bool,
+    duration:Optional[int]=None,
     type:Optional[Literal["ctftime", "custom"]]=None,
     archived:Optional[bool]=None,
-    id:Optional[int]=None,
-    channel_id:Optional[int]=None,
-    # only for CTFTime Events
-    event_id:Optional[int]=None,
+) -> Tuple[Event, Optional[str]]:
+    """
+    Read one Event and try to lock an Event (if you want).
+    
+    :param session:
+    :param id:
+    :param lock: Whether to lock the Event.
+    :param duration: How long you want to lock the Event (in seconds).
+    :param type: Search ``ctftime``, ``custom`` Events, or ``None`` to search both types of Events.
+    :param archived: Search archived, non-archived Events, or ``None`` to search both types of Events.
+    
+    :return Event:
+    :return Optional[str]: Lock owner token.
+    
+    :raise NotFoundError: Can't find the Event.
+    :raise LockedError: The Event was locked.
+    :raise ValueError:
+    :raise RuntimeError:
+    :raise (Exception from sqlalchemy):
+    """
+    # functions
+    def _build_filter(stmt:Union[sqlalchemy.Select, sqlalchemy.Update]) -> Union[sqlalchemy.Select, sqlalchemy.Update]:
+        stmt = stmt.where(Event.id == id)
+        
+        if type is not None:
+            if type == "ctftime":
+                stmt = stmt.where(Event.event_id != None)
+            elif type == "custom":
+                stmt = stmt.where(Event.event_id == None)
+            else:
+                raise ValueError(f"type should be \"ctftime\", \"custom\" or None")
+        
+        if archived is not None:
+            stmt = stmt.where(Event.archived == archived)
+        
+        return stmt
+
+    # check exists stmt
+    check_exists:sqlalchemy.Select = _build_filter(sqlalchemy.select(Event))
+    
+    # no need to lock -> execute and return
+    if lock == False:
+        check_exists = check_exists.options(selectinload(Event.users))
+        async with session.begin():
+            try:
+                event_db = (await session.execute(check_exists)).scalar_one_or_none()
+            except Exception:
+                raise
+            if event_db is None:
+                raise NotFoundError
+            return event_db, None
+    
+    # need to lock
+    # argument check
+    if duration is None:
+        raise ValueError("duration should not be None when lock is True")
+    
+    # prepare arguments
+    time_now = datetime.now(timezone.utc)
+    locked_until = time_now + timedelta(seconds=duration)
+    lock_owner_token = hashlib.sha256(os.urandom(32)).hexdigest()
+    
+    # stmt
+    check_exists_cte = check_exists.cte("check_exists_cte")
+    
+    try_lock:sqlalchemy.Update = _build_filter(sqlalchemy.update(Event))
+    try_lock_cte = (
+        try_lock
+        .where(sqlalchemy.or_(
+            Event.locked_until == None,
+            Event.locked_until < int(time_now.timestamp())
+        ))
+        .values(
+            locked_until = int(locked_until.timestamp()),
+            locked_by = lock_owner_token
+        )
+        .returning(Event)
+    ).cte("try_lock_cte")
+    
+    check_lock = sqlalchemy.exists(
+        sqlalchemy.select(try_lock_cte.c.id) \
+        .where(try_lock_cte.c.id == id) \
+        .where(try_lock_cte.c.locked_by == lock_owner_token)
+    )
+    
+    stmt = sqlalchemy.select(
+        sqlalchemy.case(
+            (check_lock, "success"),
+            else_="locked"
+        ),
+        Event
+    ) \
+    .options(selectinload(Event.users)) \
+    .join(check_exists_cte, check_exists_cte.c.id == Event.id) \
+    .where(check_exists_cte.c.id == id)
+
+    # execute
+    async with session.begin():
+        results = (await session.execute(stmt)).all()
+        if len(results) == 0:
+            raise NotFoundError
+        else:
+            status = results[0][0]
+            event_db = results[0][1]
+            if status == "success":
+                return event_db, lock_owner_token
+            elif status == "locked":
+                raise LockedError
+            else:
+                raise RuntimeError("unexpected lock status")
+
+
+async def read_event_many(
+    session:AsyncSession,
+    type:Literal["ctftime", "custom"],
+    archived:Optional[bool]=None,
+    limit:Optional[int]=None,
+    # ctftime events
     finish_after:Optional[int]=None,
+    finish_before:Optional[int]=None,
+    # ctftime events (finish_before mode) and custom events
+    before_id:Optional[int]=None,
 ) -> List[Event]:
     """
     Read Events.
     
+    There are two types of Events:
+    - ``type=ctftime``
+        - finish_after mode
+            - Search Events which are finish after ``finish_after``
+        - finish_before mode
+            - Search Events (1) which are finish before ``finish_before`` (2) with id smaller than ``before_id``
+            - ``finish_before`` - ``finish`` of the last event in previous page
+            - ``before_id`` - ``id`` of the last event in previous page
+            - ``finish_before=None`` and ``before_id=None`` for "first page"
+            - ``limit`` is required
+    - ``type=custom``
+        - Search Events with id smaller than ``before_id``
+        - ``before_id=None`` for "first page"
+        - ``limit`` is required
+    
     :param session:
-    :param lock_owner_token:
-    :param type: Search "ctftime", "custom" Events, or ``None`` to search both types of Events.
+    :param type: Search ``ctftime`` or ``custom`` Events.
     :param archived: Search archived, non-archived Events, or ``None`` to search both types of Events.
-    :param id:
-    :param channel_id: Discord channel ID.
-    :param event_id: (CTFTime Event only) CTFTime Event id.
-    :param finish_after: (CTFTime Event only) search CTFTime Events which finish after ``finish_after``.
+    :param limit:
+    :param finish_after:
+    :param finish_before:
+    :param before_id:
     
     :return List[Event]: A list of Events.
     
-    :raise ValueError: Invalid arguments.
-    :raise RuntimeError:
+    :raise ValueError:
     :raise (Exception from sqlalchemy):
     """
     # stmt
@@ -316,56 +523,64 @@ async def read_event(
         .options(selectinload(Event.users))
     
     # arguments
-    if type is not None:
-        if type == "ctftime":
-            if event_id is not None:
-                stmt = stmt.where(Event.event_id == event_id)
-            else:
-                stmt = stmt.where(Event.event_id != None)
+    if type == "ctftime":
+        stmt = stmt.where(Event.event_id != None) \
+            .order_by(sqlalchemy.desc(Event.finish), sqlalchemy.desc(Event.id))
+        
+        if finish_after is not None:
+            # finish_after mode
+            if (finish_before is not None) or (limit is not None) or (before_id is not None):
+                raise ValueError("finish_before, limit and before_id are not available for CTFTime Events in finish_after mode")
             
-            if finish_after is not None:
-                stmt = stmt.where(Event.finish >= finish_after)
-            
-            # sorting
-            stmt = stmt.order_by(sqlalchemy.asc(Event.finish))
-        elif type == "custom":
-            stmt = stmt.where(Event.event_id == None)
+            stmt = stmt.where(Event.finish >= finish_after)
         else:
-            raise ValueError(f"type should be \"ctftime\", \"custom\" or None")
+            # finish_before mode
+            
+            # limit
+            if (limit is None) or (limit <= 0):
+                raise ValueError("limit is required and must be greater than 0 for CTFTime Events in finish_before mode")
+            
+            stmt = stmt.limit(limit)
+            
+            # finish_before & before_id
+            if (finish_before is not None) and (before_id is not None):
+                stmt = stmt.where(sqlalchemy.or_(
+                    Event.finish < finish_before,
+                    sqlalchemy.and_(
+                        Event.finish == finish_before,
+                        Event.id < before_id
+                    )
+                ))
+            else:
+                if (finish_before is None) and (before_id is None):
+                    # first page
+                    pass
+                else:
+                    raise ValueError("invalid finish_before and before_id for CTFTime Events in finish_before mode")
+    elif type == "custom":
+        if (finish_after is not None) or (finish_before is not None):
+            raise ValueError("finish_after and finish_before are not available for custom Events")
+
+        if (limit is None) or (limit <= 0):
+            raise ValueError("limit is required and must be greater than 0 for custom Events")
+        
+        stmt = stmt.where(Event.event_id == None) \
+            .order_by(sqlalchemy.desc(Event.id)) \
+            .limit(limit)
+        
+        if before_id is not None:
+            stmt = stmt.where(Event.id < before_id)
+    else:
+        raise ValueError("invalid type")
     
     if archived is not None:
         stmt = stmt.where(Event.archived == archived)
-    
-    if id is not None:
-        stmt = stmt.where(Event.id == id)
-    
-    if channel_id is not None:
-        stmt = stmt.where(Event.channel_id == channel_id)
-    
+
     # execute
     try:
-        results = (await session.execute(stmt)).scalars().all()
+        return (await session.execute(stmt)).scalars().all()
     except Exception:
         raise
-    
-    # check lock
-    if lock_owner_token is not None:
-        # only effective when conditions include unique columes.
-        if (id is not None or \
-                channel_id is not None or \
-                event_id is not None) and \
-                len(results) == 1:
-            result = results[0]
-            
-            time_now = datetime.now(timezone.utc)
-            
-            if result.locked_by is None or \
-                    result.locked_by != lock_owner_token or \
-                    result.locked_until is None or \
-                    result.locked_until < int(time_now.timestamp()):
-                raise RuntimeError("Invalid lock")
-    
-    return results
 
 
 async def read_ctfime_events_need_archive(session:AsyncSession, finish_before:int) -> List[Event]:

--- a/src/crud/event.py
+++ b/src/crud/event.py
@@ -230,7 +230,7 @@ async def join_event(
     
     # execute
     try:
-        result = (await session.execute(stmt)).one()
+        (await session.execute(stmt)).one()
         await session.flush()
         return
     except Exception:
@@ -351,6 +351,7 @@ async def create_event(
     try:
         result = (await session.execute(stmt)).scalar_one()
         await session.flush()
+        await session.refresh(result)
         return result
     except Exception:
         raise
@@ -367,6 +368,8 @@ async def read_event_one(
 ) -> Tuple[Event, Optional[str]]:
     """
     Read one Event and try to lock an Event (if you want).
+    
+    Inside this function, it uses ``async with session.begin()``.
     
     :param session:
     :param id:
@@ -671,6 +674,7 @@ async def update_event(
     try:
         result = (await session.execute(stmt)).scalar_one()
         await session.flush()
+        await session.refresh(result)
         return result
     except Exception:
         raise

--- a/src/crud/user.py
+++ b/src/crud/user.py
@@ -29,6 +29,7 @@ async def create_user(session:AsyncSession, discord_id:int) -> User:
     try:
         result = (await session.execute(stmt)).scalar_one()
         await session.flush()
+        await session.refresh(result)
         return result
     except Exception:
         raise
@@ -103,6 +104,7 @@ async def update_user(
     try:
         result = (await session.execute(stmt)).scalar_one()
         await session.flush()
+        await session.refresh(result)
         return result
     except Exception:
         raise

--- a/src/router/__init__.py
+++ b/src/router/__init__.py
@@ -2,3 +2,4 @@ from .auth import router as auth_router
 from .user import router as user_router
 from .ctf import router as ctf_router
 from .config import router as config_router
+from .guild import router as guild_router

--- a/src/router/config.py
+++ b/src/router/config.py
@@ -1,12 +1,11 @@
 from typing import Optional
 import logging
 
-from fastapi import APIRouter, HTTPException, Request, Depends
+from fastapi import APIRouter, HTTPException, Depends
 import discord
 
 from src.backend import security
 from src.backend import config as config_backend
-from src.bot import get_bot
 from src import schema
 
 # logger
@@ -22,9 +21,8 @@ async def read_config(
     key:Optional[str]=None,
     member:discord.Member=Depends(security.fastapi_check_administrator)
 ) -> schema.ConfigResponse:
-    bot = await get_bot()
     try:
-        config_info = await config_backend.read_config(bot, key)
+        config_info = await config_backend.read_config(key)
     except HTTPException:
         raise
     except Exception as e:
@@ -42,9 +40,8 @@ async def update_config(
     member:discord.Member=Depends(security.fastapi_check_administrator),
 ) -> schema.General:
     # update config
-    bot = await get_bot()
     try:
-        await config_backend.update_config(bot, (key, data.value))
+        await config_backend.update_config((key, data.value))
     except HTTPException:
         raise
     except Exception as e:

--- a/src/router/ctf.py
+++ b/src/router/ctf.py
@@ -9,6 +9,7 @@ from src.database.database import fastapi_get_db
 from src.backend import security
 from src.backend import channel_op
 from src.backend import event as event_backend
+from src.bot import get_guild
 from src import schema
 from src import crud
 
@@ -67,7 +68,7 @@ async def read_all_ctftime_event(
         raise HTTPException(500, "fail to read Events from database")
     
     # format and return
-    return (await event_backend.format_event((await event_backend.get_guild()), events_db))
+    return (await event_backend.format_event(get_guild(), events_db))
 
 
 @router.get("/custom")
@@ -94,7 +95,7 @@ async def read_all_custom_event(
         raise HTTPException(500, "fail to read Events from database")
     
     # format and return
-    return (await event_backend.format_event((await event_backend.get_guild()), events_db))
+    return (await event_backend.format_event(get_guild(), events_db))
 
 
 @router.get("/{event_db_id}")
@@ -117,7 +118,7 @@ async def read_event(
         raise HTTPException(500, f"fail to read Event (id={event_db_id}) from database")
     
     # format and return
-    return (await event_backend.format_event((await event_backend.get_guild()), [event_db]))[0]
+    return (await event_backend.format_event(get_guild(), [event_db]))[0]
 
 
 # update - join

--- a/src/router/ctf.py
+++ b/src/router/ctf.py
@@ -1,7 +1,7 @@
 from typing import Optional, List, Literal
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 import discord
 
@@ -10,6 +10,7 @@ from src.backend import security
 from src.backend import channel_op
 from src.backend import event as event_backend
 from src import schema
+from src import crud
 
 # logger
 logger = logging.getLogger("uvicorn")
@@ -35,26 +36,65 @@ async def create_custom_event(
 
 
 # read
-@router.get("/")
-async def read_event_all(
-    type:Literal["ctftime", "custom"],
+@router.get("/ctftime")
+async def read_all_ctftime_event(
     archived:Optional[bool]=None,
+    limit:int=Query(gt=0, le=20),
+    finish_before:Optional[int]=Query(ge=0, default=None),
+    before_id:Optional[int]=Query(ge=0, default=None),
     session:AsyncSession=Depends(fastapi_get_db),
-    member:discord.Member=Depends(security.fastapi_check_user)
+    member:discord.Member=Depends(security.fastapi_check_user),
 ) -> List[schema.Event]:
-    try:
-        events = await event_backend.get_event(
-            session=session,
-            type=type,
-            archived=archived
-        )
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"fail to read Events: {str(e)}")
-        raise HTTPException(500, "fail to read Events")
+    # argument check
+    first_page = (finish_before is None) and (before_id is None)
+    n_page = (finish_before is not None) and (before_id is not None)
+    if first_page == False and n_page == False:
+        raise HTTPException(400, "invalid finish_before and before_id")
     
-    return events
+    # get events from database
+    try:
+        events_db = await crud.read_event_many(
+            session=session,
+            type="ctftime",
+            archived=archived,
+            limit=limit,
+            finish_after=None,
+            finish_before=finish_before,
+            before_id=before_id
+        )
+    except Exception as e:
+        logger.error(f"fail to read Events from database: {str(e)}")
+        raise HTTPException(500, "fail to read Events from database")
+    
+    # format and return
+    return event_backend.format_event((await event_backend.get_guild()), events_db)
+
+
+@router.get("/custom")
+async def read_all_custom_event(
+    archived:Optional[bool]=None,
+    limit:int=Query(gt=0, le=20),
+    before_id:Optional[int]=Query(ge=0, default=None),
+    session:AsyncSession=Depends(fastapi_get_db),
+    member:discord.Member=Depends(security.fastapi_check_user),
+) -> List[schema.Event]:
+    # get events from database
+    try:
+        events_db = await crud.read_event_many(
+            session=session,
+            type="custom",
+            archived=archived,
+            limit=limit,
+            finish_after=None,
+            finish_before=None,
+            before_id=before_id
+        )
+    except Exception as e:
+        logger.error(f"fail to read Events from database: {str(e)}")
+        raise HTTPException(500, "fail to read Events from database")
+    
+    # format and return
+    return event_backend.format_event((await event_backend.get_guild()), events_db)
 
 
 @router.get("/{event_db_id}")
@@ -62,16 +102,22 @@ async def read_event(
     event_db_id:int,
     session:AsyncSession=Depends(fastapi_get_db),
     member:discord.Member=Depends(security.fastapi_check_user)
-) -> List[schema.Event]:
+) -> schema.Event:
+    # get event from database
     try:
-        events = await event_backend.get_event(session=session, id=event_db_id)
-    except HTTPException:
-        raise
+        event_db, _ = await crud.read_event_one(
+            session,
+            lock=False,
+            id=event_db_id
+        )
+    except crud.NotFoundError:
+        raise HTTPException(404, f"Event (id={event_db_id}) not found")
     except Exception as e:
-        logger.error(f"fail to read Events: {str(e)}")
-        raise HTTPException(500, "fail to read Events")
+        logger.error(f"fail to read Event (id={event_db_id}) from database: {str(e)}")
+        raise HTTPException(500, f"fail to read Event (id={event_db_id}) from database")
     
-    return events
+    # format and return
+    return event_backend.format_event((await event_backend.get_guild()), [event_db])[0]
 
 
 # update - join

--- a/src/router/ctf.py
+++ b/src/router/ctf.py
@@ -67,7 +67,7 @@ async def read_all_ctftime_event(
         raise HTTPException(500, "fail to read Events from database")
     
     # format and return
-    return event_backend.format_event((await event_backend.get_guild()), events_db)
+    return (await event_backend.format_event((await event_backend.get_guild()), events_db))
 
 
 @router.get("/custom")
@@ -94,7 +94,7 @@ async def read_all_custom_event(
         raise HTTPException(500, "fail to read Events from database")
     
     # format and return
-    return event_backend.format_event((await event_backend.get_guild()), events_db)
+    return (await event_backend.format_event((await event_backend.get_guild()), events_db))
 
 
 @router.get("/{event_db_id}")
@@ -117,7 +117,7 @@ async def read_event(
         raise HTTPException(500, f"fail to read Event (id={event_db_id}) from database")
     
     # format and return
-    return event_backend.format_event((await event_backend.get_guild()), [event_db])[0]
+    return (await event_backend.format_event((await event_backend.get_guild()), [event_db]))[0]
 
 
 # update - join

--- a/src/router/guild.py
+++ b/src/router/guild.py
@@ -1,0 +1,59 @@
+from typing import List
+import logging
+
+from fastapi import APIRouter, Depends
+import discord
+
+from src.backend.security import fastapi_check_user
+from src.bot import get_guild
+from src import schema
+
+# logger
+logger = logging.getLogger("uvicorn")
+
+# router
+router = APIRouter(prefix="/guild", tags=["Guild"])
+
+@router.get("/text_channels")
+async def guild_text_channels(
+    member:discord.Member=Depends(fastapi_check_user),
+    guild:discord.Guild=Depends(get_guild)
+) -> List[schema.DiscordTextChannel]:
+    results = []
+    for c in guild.text_channels:
+        if c.permissions_for(member).view_channel == True:
+            results.append(schema.DiscordTextChannel(
+                id=c.id,
+                jump_url=c.jump_url,
+                name=c.name
+            ))
+    return results
+
+
+@router.get("/categories")
+async def guild_categories(
+    member:discord.Member=Depends(fastapi_check_user),
+    guild:discord.Guild=Depends(get_guild),
+) -> List[schema.DiscordCategoryChannel]:
+    results = []
+    for c in guild.categories:
+        if c.permissions_for(member).view_channel == True:
+            results.append(schema.DiscordCategoryChannel(
+                id=c.id,
+                jump_url=c.jump_url,
+                name=c.name
+            ))
+    return results
+
+
+@router.get("/roles")
+async def guild_roles(
+    member:discord.Member=Depends(fastapi_check_user),
+    guild:discord.Guild=Depends(get_guild),
+) -> List[schema.DiscordRole]:
+    return [
+        schema.DiscordRole(
+            id=r.id,
+            name=r.name
+        ) for r in guild.roles
+    ]

--- a/src/router/user.py
+++ b/src/router/user.py
@@ -22,11 +22,17 @@ router = APIRouter(prefix="/user", tags=["User"])
 # delete - (nope)
 
 @router.get("/")
-@router.get("/{discord_id}")
-async def read_user(
-    discord_id:Optional[int]=None,
+async def read_all_user(
     session:AsyncSession=Depends(fastapi_get_db),
     member:discord.Member=Depends(fastapi_check_user)
 ) -> List[schema.User]:
-    users = await user.get_user(session, discord_id)
-    return users
+    return (await user.get_user(session))
+
+
+@router.get("/{discord_id}")
+async def read_user(
+    discord_id:int,
+    session:AsyncSession=Depends(fastapi_get_db),
+    member:discord.Member=Depends(fastapi_check_user)
+) -> schema.User:
+    return (await user.get_user(session, discord_id))[0]

--- a/src/schema/__init__.py
+++ b/src/schema/__init__.py
@@ -1,6 +1,6 @@
 from .general import General
 from .config import Config, ConfigResponse, UpdateConfig
-from .user import UserSimple, User, DiscordUser, UpdateUser
+from .user import UserRole, UserSimple, User, DiscordUser, UpdateUser
 from .event import DiscordChannel, EventSimple, Event, CreateCustomEvent, RelinkEvent
 
 User.model_rebuild()

--- a/src/schema/__init__.py
+++ b/src/schema/__init__.py
@@ -1,7 +1,10 @@
 from .general import General
 from .config import Config, ConfigResponse, UpdateConfig
 from .user import UserRole, UserSimple, User, DiscordUser, UpdateUser
-from .event import DiscordChannel, EventSimple, Event, CreateCustomEvent, RelinkEvent
+from .event import EventSimple, Event, CreateCustomEvent, RelinkEvent
+from .guild import DiscordTextChannel, DiscordCategoryChannel, DiscordRole
 
 User.model_rebuild()
+
+EventSimple.model_rebuild()
 Event.model_rebuild()

--- a/src/schema/event.py
+++ b/src/schema/event.py
@@ -14,12 +14,6 @@ class RelinkEvent(BaseModel):
 
 
 # response schema
-class DiscordChannel(BaseModel):
-    id:int
-    jump_url:str
-    name:str
-
-
 class EventSimple(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     
@@ -32,7 +26,7 @@ class EventSimple(BaseModel):
     finish:Optional[int]=None
     
     channel_id:Optional[int]=None
-    channel:Optional[DiscordChannel]=None
+    channel:Optional["DiscordTextChannel"]=None
     scheduled_event_id:Optional[int]=None
     
     # extra attrbutes

--- a/src/schema/guild.py
+++ b/src/schema/guild.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+# response schema
+class DiscordTextChannel(BaseModel):
+    id:int
+    jump_url:str
+    name:str
+
+
+class DiscordCategoryChannel(BaseModel):
+    id:int
+    jump_url:str
+    name:str
+
+
+class DiscordRole(BaseModel):
+    id:int
+    name:str

--- a/src/schema/user.py
+++ b/src/schema/user.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import Optional, List
+from enum import Enum
 
 from pydantic import BaseModel, ConfigDict
 
@@ -13,6 +14,12 @@ class UpdateUser(BaseModel):
 
 
 # get
+class UserRole(Enum):
+    administrator="Administrator"
+    pm="pm"
+    member="member"
+
+
 class DiscordUser(BaseModel):
     display_name:str
     id:int
@@ -23,6 +30,7 @@ class UserSimple(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     
     discord_id:int
+    user_role:List[UserRole]
     
     status:model.Status
     skills:List[model.Skills]

--- a/src/utils/notification.py
+++ b/src/utils/notification.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 import discord
 
-from src.bot import get_bot
+from src.bot import get_guild
 from src.config import settings
 
 async def send_notification(
@@ -22,9 +22,9 @@ async def send_notification(
     
     :raise RuntimeError:
     """
-    bot = await get_bot()
-    guild = bot.get_guild(settings.GUILD_ID)
-    if guild is None:
+    try:
+        guild = get_guild()
+    except Exception:
         raise RuntimeError(f"Guild (id={settings.GUILD_ID}) not found")
     
     # args


### PR DESCRIPTION
## What changed
- improved event database lock
- Migrated event access to `read_event_one` / `read_event_many` and updated related callers.
- Added guild info APIs:
  - `GET /guild/text_channels`
  - `GET /guild/categories`
  - `GET /guild/roles`
- Unified guild access through shared `get_guild()` usage across modules.

## Notes
- This PR includes API/schema response changes.
- Recommended checks: event read/lock flow, guild routes, and `ctfmenu` pagination behavior.